### PR TITLE
Read comprehensive JSONL

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -82,6 +82,12 @@
             <ul>
               <li v-for="cde in comprehensive[filename]" :key="cde.id">
                 {{cde.id}}
+                <textarea
+                    disabled
+                    class="cde_text"
+                    rows="20"
+                    v-model="cde.text"
+                ></textarea>
               </li>
             </ul>
           </li>
@@ -150,9 +156,9 @@ export default {
             }
             this.comprehensive[filename].push({
               id: `HEALCDE:${filename}`,
-              ...entry
+              text: entry['_ner']['scigraph']['crf_text'],
             });
-            console.log("Found entry for", filename);
+            console.log("Found entry for", filename, "with keys", keys(entry['_ner']));
           });
           this.input_in_progress = false;
         });
@@ -238,5 +244,9 @@ export default {
   text-align: center;
   color: #2c3e50;
   margin-top: 60px;
+}
+
+textarea.cde_text {
+  width: 100%;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -191,7 +191,7 @@ export default {
               id: `HEALCDE:${filename}`,
               designations: entry['designations'],
               formElements: entry['formElements'],
-              text: entry['_ner']['scigraph']['crf_text'],
+              text: entry['_ner']['oger']['crf_text'],
             });
             // console.log("Found entry for", filename, "with keys", keys(entry['_ner']));
           });

--- a/src/App.vue
+++ b/src/App.vue
@@ -145,10 +145,18 @@ export default {
   }},
   watch: {
     nodes_file() {
-      this.nodes_file.text().then(content => { this.nodes_text = content })
+      this.input_in_progress = true;
+      this.nodes_file.text().then(content => {
+        this.nodes_text = content;
+        this.input_in_progress = false;
+      });
     },
     edges_file() {
-      this.edges_file.text().then(content => { this.edges_text = content })
+      this.input_in_progress = true;
+      this.edges_file.text().then(content => {
+        this.edges_text = content;
+        this.input_in_progress = false;
+      });
     },
     comprehensive_file() {
       this.input_in_progress = true;

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,11 +4,22 @@
 
     <div class="col-10 m-auto">
       <b-card header="Inputs" class="mt-3">
+        <b-alert variant="danger" show class="text-left" v-if="input_errors.length > 0">
+          <p>Errors occurred while reading input files:</p>
+          <ul>
+            <li v-for="err in input_errors" :key="err.row">
+              Row {{err.row}}: {{err.text}}
+            </li>
+          </ul>
+        </b-alert>
         <b-input-group prepend="KGX nodes file">
           <b-form-file v-model="nodes_file"></b-form-file>
         </b-input-group>
         <b-input-group prepend="KGX edges file">
           <b-form-file v-model="edges_file"></b-form-file>
+        </b-input-group>
+        <b-input-group prepend="Comprehensive JSONL file">
+          <b-form-file v-model="comprehensive_file"></b-form-file>
         </b-input-group>
       </b-card>
 
@@ -70,10 +81,13 @@ import { groupBy, toPairs, cloneDeep, has } from 'lodash'
 export default {
   name: 'App',
   data() { return {
+    input_errors: [],
     nodes_file: null,
     nodes_text: "",
     edges_file: null,
     edges_text: "",
+    comprehensive_file: null,
+    comprehensive: [],
     selected_category: "",
     selected_concept: "",
     PREFIXES: {
@@ -89,6 +103,21 @@ export default {
     edges_file() {
       this.edges_file.text().then(content => { this.edges_text = content })
     },
+    comprehensive_file() {
+      this.comprehensive_file.text().then(content => {
+        this.input_errors = [];
+        this.comprehensive = content.split('\n').map((row, index) => {
+          try {
+            return JSON.parse(row);
+          } catch (err) {
+            this.input_errors.append({
+              row,
+              text: `Could not parse comprehensive JSONL line ${index}: ${err} (while parsing line: ${row})`
+            })
+          }
+        });
+      });
+    }
   },
   computed: {
     nodes() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -81,13 +81,7 @@
             <a :id="'HEALCDE:' + filename">{{filename}}</a>
             <ul>
               <li v-for="cde in comprehensive[filename]" :key="cde.id">
-                {{cde.id}}
-                <textarea
-                    disabled
-                    class="cde_text"
-                    rows="20"
-                    v-model="cde.text"
-                ></textarea>
+                <HEALCDE :cde="cde" />
               </li>
             </ul>
           </li>
@@ -103,8 +97,11 @@
 import { groupBy, toPairs, cloneDeep, has, keys } from 'lodash'
 import Vue from 'vue'
 
+import HEALCDE from './components/HEALCDE'
+
 export default {
   name: 'App',
+  components: { HEALCDE },
   data() { return {
     input_in_progress: false,
     input_errors: [],
@@ -156,9 +153,11 @@ export default {
             }
             this.comprehensive[filename].push({
               id: `HEALCDE:${filename}`,
+              designations: entry['designations'],
+              formElements: entry['formElements'],
               text: entry['_ner']['scigraph']['crf_text'],
             });
-            console.log("Found entry for", filename, "with keys", keys(entry['_ner']));
+            // console.log("Found entry for", filename, "with keys", keys(entry['_ner']));
           });
           this.input_in_progress = false;
         });

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,12 +46,13 @@
                       <a :href="'#' + concept.name"
                          @click="selected_concept=(selected_concept === concept.name ? '' : concept.name)"
                       >
-                      {{concept.name}} ({{concept.id}}): {{get_cdes_for_concept(concept).length}} CRFs
+                      {{concept.name}}: {{get_cdes_for_concept(concept).length}} CRFs
                       </a>
+                      (<a target="code" :href="get_uri_for_curie(concept.id)">{{concept.id}}</a>)
 
                       <ul v-if="selected_concept == concept.name && get_cdes_for_concept(concept)">
                         <li v-for="cde in get_cdes_for_concept(concept)" :key="cde['id']">
-                          <tt>{{cde.terms}}</tt> in <a :href="'#' + category.name" @click="selected_category_cde = comprehensive[cde.id.substring(8)]">{{cde.id}}</a>
+                          <tt>{{cde.terms}}</tt> in <a :href="'#' + category.name" @click="selected_category_cde = comprehensive[cde.id.substring(8)]; selected_category_text = cde.terms;">{{cde.id}}</a>
                         </li>
                       </ul>
                     </li>
@@ -64,7 +65,7 @@
 
           <div v-if="selected_category_cde" class="col-5">
             <b-card class="mt-3" v-for="cde in selected_category_cde" :key="cde.id" :header="cde.id">
-              <HEALCDE :cde="cde" />
+              <HEALCDE :cde="cde" :highlight_text="selected_category_text" />
             </b-card>
           </div>
         </div>
@@ -81,7 +82,7 @@
                   (<a target="code" :href="get_uri_for_curie(concept.id)">{{concept.id}}</a>): {{concept.count}} CRFs
                   <ul v-if="selected_concept === concept.name">
                     <li v-for="cde in concept.cdes" :key="cde['id']">
-                      <tt>{{cde.terms}}</tt> in <a :href="'#' + concept.name"  @click="selected_concept_cde = comprehensive[cde.id.substring(8)]">{{cde.id}}</a>
+                      <tt>{{cde.terms}}</tt> in <a :href="'#' + concept.name"  @click="selected_concept_cde = comprehensive[cde.id.substring(8)];  selected_concept_text = cde.terms;">{{cde.id}}</a>
                     </li>
                   </ul>
                 </li>
@@ -91,12 +92,13 @@
 
           <div v-if="selected_concept_cde" class="col-5">
             <b-card class="mt-3" v-for="cde in selected_concept_cde" :key="cde.id" :header="cde.id">
-              <HEALCDE :cde="cde" />
+              <HEALCDE :cde="cde" :highlight_text="selected_concept_text" />
             </b-card>
           </div>
         </div>
       </div>
 
+      <!--
       <b-card header="CDEs" class="mt-3">
         <ul style="text-align: left">
           <li v-for="filename in comprehensive_keys" :key="filename">
@@ -108,7 +110,7 @@
             </ul>
           </li>
         </ul>
-      </b-card>
+      </b-card> -->
 
       <p></p>
     </div>
@@ -136,7 +138,9 @@ export default {
     selected_category: "",
     selected_concept: "",
     selected_category_cde: null,
+    selected_category_text: null,
     selected_concept_cde: null,
+    selected_concept_text: null,
     PREFIXES: {
       'HP': 'http://purl.obolibrary.org/obo/HP_',
       'GO': 'http://purl.obolibrary.org/obo/GO_',

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,48 +32,70 @@
         The comprehensive JSONL file contains {{comprehensive_keys.length}} CDEs.
       </b-card>
 
-      <b-card header="Concepts by categories" class="mt-3">
-        <ul style="text-align: left">
-          <li v-for="category in concept_categories" :key="category.name" :id="category.name">
-            <a :href="'#' + category.name"
-              @click="selected_category=(selected_category == category.name ? '' : category.name)">{{category.name}}</a> ({{category.count}})
+      <div class="container col-12">
+        <div class="row">
+          <div :class="selected_category_cde ? 'col-7' : 'col-12'">
+            <b-card header="Concepts by categories" class="mt-3">
+              <ul style="text-align: left">
+                <li v-for="category in concept_categories" :key="category.name" :id="category.name">
+                  <a :href="'#' + category.name"
+                    @click="selected_category=(selected_category == category.name ? '' : category.name)">{{category.name}}</a> ({{category.count}})
 
-            <ul v-if="selected_category == category.name">
-              <li v-for="concept in category.concepts" :key="concept['id']">
-                <a :href="'#' + concept.name"
-                   @click="selected_concept=(selected_concept === concept.name ? '' : concept.name)"
-                >
-                {{concept.name}} ({{concept.id}}): {{get_cdes_for_concept(concept).length}} CRFs
-                </a>
+                  <ul v-if="selected_category == category.name">
+                    <li v-for="concept in category.concepts" :key="concept['id']">
+                      <a :href="'#' + concept.name"
+                         @click="selected_concept=(selected_concept === concept.name ? '' : concept.name)"
+                      >
+                      {{concept.name}} ({{concept.id}}): {{get_cdes_for_concept(concept).length}} CRFs
+                      </a>
 
-                <ul v-if="selected_concept == concept.name && get_cdes_for_concept(concept)">
-                  <li v-for="cde in get_cdes_for_concept(concept)" :key="cde['id']">
-                    <tt>{{cde.terms}}</tt> in <a :href="'#' + cde.id">{{cde.id}}</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
+                      <ul v-if="selected_concept == concept.name && get_cdes_for_concept(concept)">
+                        <li v-for="cde in get_cdes_for_concept(concept)" :key="cde['id']">
+                          <tt>{{cde.terms}}</tt> in <a :href="'#' + category.name" @click="selected_category_cde = comprehensive[cde.id.substring(8)]">{{cde.id}}</a>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
 
-          </li>
-        </ul>
-      </b-card>
+                </li>
+              </ul>
+            </b-card>
+          </div>
 
-      <b-card header="Concepts by count" class="mt-3">
-        <ul style="text-align: left">
-          <li v-for="concept in sorted_concepts" :key="concept.name">
+          <div v-if="selected_category_cde" class="col-5">
+            <b-card class="mt-3" v-for="cde in selected_category_cde" :key="cde.id" :header="cde.id">
+              <HEALCDE :cde="cde" />
+            </b-card>
+          </div>
+        </div>
 
-            <a :href="'#count_for_' + concept.name"
-               @click="selected_concept=(selected_concept === concept.name ? '' : concept.name)"
-            >{{concept.name}}</a>
-            (<a target="code" :href="get_uri_for_curie(concept.id)">{{concept.id}}</a>): {{concept.count}} CRFs
-            <ul v-if="selected_concept === concept.name">
-              <li v-for="cde in concept.cdes" :key="cde['id']">
-                <tt>{{cde.terms}}</tt> in <a :href="'#' + cde.id">{{cde.id}}</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </b-card>
+        <div class="row">
+          <div :class="selected_category_cde ? 'col-7' : 'col-12'">
+            <b-card header="Concepts by count" class="mt-3">
+              <ul style="text-align: left">
+                <li v-for="concept in sorted_concepts" :key="concept.name">
+
+                  <a :href="'#count_for_' + concept.name"
+                     @click="selected_concept=(selected_concept === concept.name ? '' : concept.name)"
+                  >{{concept.name}}</a>
+                  (<a target="code" :href="get_uri_for_curie(concept.id)">{{concept.id}}</a>): {{concept.count}} CRFs
+                  <ul v-if="selected_concept === concept.name">
+                    <li v-for="cde in concept.cdes" :key="cde['id']">
+                      <tt>{{cde.terms}}</tt> in <a :href="'#' + concept.name"  @click="selected_concept_cde = comprehensive[cde.id.substring(8)]">{{cde.id}}</a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </b-card>
+          </div>
+
+          <div v-if="selected_concept_cde" class="col-5">
+            <b-card class="mt-3" v-for="cde in selected_concept_cde" :key="cde.id" :header="cde.id">
+              <HEALCDE :cde="cde" />
+            </b-card>
+          </div>
+        </div>
+      </div>
 
       <b-card header="CDEs" class="mt-3">
         <ul style="text-align: left">
@@ -113,6 +135,8 @@ export default {
     comprehensive: {},
     selected_category: "",
     selected_concept: "",
+    selected_category_cde: null,
+    selected_concept_cde: null,
     PREFIXES: {
       'HP': 'http://purl.obolibrary.org/obo/HP_',
       'GO': 'http://purl.obolibrary.org/obo/GO_',

--- a/src/App.vue
+++ b/src/App.vue
@@ -210,7 +210,7 @@ export default {
     concepts() {
       return this.nodes.filter(node => {
         let provided_by = node['provided_by']
-        if(provided_by && (provided_by[0] == 'Monarch NER service + Translator normalization API'))
+        if(provided_by && (provided_by[0] != 'Graph'))
           return true;
         return false;
       });

--- a/src/components/HEALCDE.vue
+++ b/src/components/HEALCDE.vue
@@ -8,9 +8,11 @@
         <strong>Question: </strong> {{element.label}}
       </li>
     </ul>
+    <button class="col-12" @click="toggle_textarea = !toggle_textarea">Toggle NER text</button>
     <textarea
+        v-if="toggle_textarea"
         disabled
-        class="cde_text"
+        class="cde_text col-12"
         rows="20"
         v-model="cde.text"
     ></textarea>
@@ -22,7 +24,11 @@ export default {
   name: 'HEALCDE',
   props: {
     cde: Object
-  }
+  },
+  data() { return {
+      toggle_textarea: false,
+    };
+  },
 }
 </script>
 

--- a/src/components/HEALCDE.vue
+++ b/src/components/HEALCDE.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="text-left">
     <p v-for="designation in cde.designations" :key="designation.designation">
-      <strong>Designation: </strong> {{designation}}
+      <strong>Designation: </strong> <span v-html="highlight(designation.designation)" />
     </p>
     <ul>
       <li v-for="element in cde.formElements" :key="element.label">
-        <strong>Question: </strong> {{element.label}}
+        <strong>Question: </strong> <span v-html="highlight(element.label)" />
       </li>
     </ul>
     <button class="col-12" @click="toggle_textarea = !toggle_textarea">Toggle NER text</button>
@@ -23,14 +23,34 @@
 export default {
   name: 'HEALCDE',
   props: {
-    cde: Object
+    cde: Object,
+    highlight_text: Array[String],
   },
   data() { return {
       toggle_textarea: false,
     };
   },
+  methods: {
+    highlight(text) {
+      if (!this.highlight_text) return text;
+      let highlighted_text = text;
+      this.highlight_text.forEach(text_to_highlight => {
+        const query_text = text_to_highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        console.log('text_to_highlight=', text_to_highlight, 'query_text=', query_text, 'highlighted_text=', highlighted_text);
+        highlighted_text = highlighted_text.replace(new RegExp(query_text, 'gi'), match => {
+          return `<span class="highlight">${match}</span>`;
+        })
+      });
+      return highlighted_text;
+    },
+  },
 }
 </script>
 
 <style>
+span.highlight {
+  font-size: 150%;
+  font-weight: bolder;
+  font-style: italic;
+}
 </style>

--- a/src/components/HEALCDE.vue
+++ b/src/components/HEALCDE.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-    {{cde.id}}
+  <div class="text-left">
     <p v-for="designation in cde.designations" :key="designation.designation">
       <strong>Designation: </strong> {{designation}}
     </p>

--- a/src/components/HEALCDE.vue
+++ b/src/components/HEALCDE.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    {{cde.id}}
+    <p v-for="designation in cde.designations" :key="designation.designation">
+      <strong>Designation: </strong> {{designation}}
+    </p>
+    <ul>
+      <li v-for="element in cde.formElements" :key="element.label">
+        <strong>Question: </strong> {{element.label}}
+      </li>
+    </ul>
+    <textarea
+        disabled
+        class="cde_text"
+        rows="20"
+        v-model="cde.text"
+    ></textarea>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HEALCDE',
+  props: {
+    cde: Object
+  }
+}
+</script>
+
+<style>
+</style>


### PR DESCRIPTION
Comprehensive JSONL files have information on every KGX node, allowing some of its information to be displayed when the CDE is selected (this is currently pretty closely configured for our HEAL CDE use case, but we can change that later as needed). This is generated by e.g. https://github.com/heal-data-stewards/heal-cdes/pull/16 and https://github.com/heal-data-stewards/heal-cdes/pull/14